### PR TITLE
[Vintellij] Possibility to toggle auto refresh file and health check within a vim session

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,24 @@ Make Intellij as a server language protocol.
 #### Dependencies
 - [fzf](https://github.com/junegunn/fzf.vim)
 
-#### Intall
+#### Install
 
+```
 Plug 'dinhhuy258/vintellij'
+```
+The default mapping is
+- <leader>gcd to go to the definition from the symbol under cursor
+- <leader>co to open the current file from vim by intelliJ
+- <leader>ci to suggest possible imports by the symbol under cursor
+
+if you want to make your own custom keymap, then put the following in your `.vimrc`
+
+```
+let g:vintellij_use_default_keymap = 0
+nnoremap <Leader>gcd :VintellijGoToDefinition<CR>
+nnoremap <Leader>co :VintellijOpenFile<CR>
+nnoremap <Leader>ci :VintellijSuggestImports<CR>
+```
 
 ### Intellij plugin
 
@@ -28,8 +43,24 @@ Plug 'dinhhuy258/vintellij'
 
 - `vintellij#RefreshFile()`: tell IntelliJ to refresh the VirtualFile element otherwise the `suggest imports` and `go to definition` features will not work correctly. This method will be called automatically each time the java/kotlin buffer is saved to file. If you want to disable it, set variable `g:vintellij_refresh_on_save` to 0 (It may cause the problem on the `suggest imports` and `go to definition` features)
 
+  To disable auto refresh file, use the command
+  ```
+    VintellijEnableAutoRefreshFile!
+    ```
+  To enable again
+  ```
+      VintellijEnableAutoRefreshFile
+      ```
 - `vintellij#HealthCheck()`: check if the plugin server is working or not. This method will be called automatically each time the java/kotlin buffer is loaded. If you want to disable it, set variable `g:vintellij_health_check_on_load` to 0.
 
+  To disable auto health check, use the command
+    ```
+    VintellijEnableHealthCheckOnLoad!
+        ```
+  To enable again
+    ```
+    VintellijEnableHealthCheckOnLoad
+        ```
 ## Features
 
 | Name | Kotlin | Java |
@@ -43,4 +74,6 @@ Plug 'dinhhuy258/vintellij'
 
 - To make it work, the Intellij must open the same project as Vim.
 - Saving file before using `suggest imports`, `go to definition`... features otherwise the features will not work correctly.
-- Always open Intellij otherwise everything will be slow.
+- Always open Intellij otherwise everything will be slow - the workarround maybe:
+  - Get IntelliJ focused by having it in your secondary screen
+  - Get vim transparent and putting IntelliJ behind

--- a/autoload/vintellij.vim
+++ b/autoload/vintellij.vim
@@ -146,6 +146,24 @@ function! vintellij#HealthCheck() abort
   call s:SendRequest('health-check', {})
 endfunction
 
+function! vintellij#EnableAutoRefreshFile(isDisable)
+  augroup vintellij_on_kt_java_file_save
+    autocmd!
+    if !a:isDisable
+      autocmd BufWritePost,FileReadPost *.kt,*.java call vintellij#RefreshFile()
+    endif
+  augroup END
+endfunction
+
+function! vintellij#EnableHealthCheckOnLoad(isDisable)
+  augroup vintellij_on_kt_java_file_load
+    autocmd!
+    if !a:isDisable
+      autocmd BufReadPost,FileReadPost *.kt,*.java call vintellij#HealthCheck()
+    endif
+  augroup END
+endfunction
+
 let &cpo = s:cpo_save
 unlet s:cpo_save
 

--- a/plugin/vintellij.vim
+++ b/plugin/vintellij.vim
@@ -1,14 +1,20 @@
-if get(g:, 'vintellij_refresh_on_save', 1)
-  augroup vintellij_on_kt_java_file_save
-    autocmd!
-    autocmd BufWritePost,FileReadPost *.kt,*.java call vintellij#RefreshFile()
-  augroup END
+command! -bang VintellijEnableAutoRefreshFile call vintellij#EnableAutoRefreshFile(<bang>0)
+command! -bang VintellijEnableHealthCheckOnLoad call vintellij#EnableHealthCheckOnLoad(<bang>0)
+
+if get(g:, 'vintellij_refresh_on_save', 1) == 1
+  VintelljEnableAutoRefreshFile
 endif
 
-if get(g:, 'vintellij_health_check_on_load', 1)
-  augroup vintellij_on_kt_java_file_load
-    autocmd!
-    autocmd BufReadPost,FileReadPost *.kt,*.java call vintellij#HealthCheck()
-  augroup END
+if get(g:, 'vintellij_health_check_on_load', 1) == 1
+  VintelljEnableHealthCheckOnLoad
 endif
 
+command! VintellijGoToDefinition :call vintellij#GoToDefinition()<CR>
+command! VintellijOpenFile :call vintellij#OpenFile()<CR>
+command! VintellijSuggestImports :call vintellij#SuggestImports()<CR>
+
+if get(g:, 'vintellij_use_default_keymap', 1) == 1
+  nnoremap <Leader>gcd :VintellijGoToDefinition<CR>
+  nnoremap <Leader>co :VintellijOpenFile<CR>
+  nnoremap <Leader>ci :VintellijSuggestImports<CR>
+endif


### PR DESCRIPTION
Some improvements:
 - Possibility to toggle autocmd of refresh file and health check within a vim session. E.g to enable auto file refresh, just use the command VintellijEnableAutoRefreshFile or VintellijEnableAutoRefreshFile! to disable it
  - Enable kotlin filetype on opening the definition